### PR TITLE
Updated `mongoose` dep and removed misspelled `getAnsestors`.

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -1,4 +1,3 @@
-
 var Schema = require('mongoose').Schema;
 
 module.exports = exports = tree;
@@ -98,7 +97,6 @@ function tree(schema, options) {
     return this.model(this.constructor.modelName).find(filter, cb);
   };
 
-  schema.method('getAnsestors', getAncestors);
   schema.method('getAncestors', getAncestors);
 
   schema.virtual('level').get(function() {

--- a/package.json
+++ b/package.json
@@ -11,18 +11,19 @@
   "version": "0.2.2",
   "engine": "node >= 0.4.0",
   "dependencies": {
-    "mongoose": "~3.5.0"
+    "mongoose": "3.x.x"
   },
   "devDependencies": {
     "async": "~0.1.22",
     "should": "~1.0.0",
-    "underscore": "~1.3.3"
+    "underscore": "~1.3.3",
+    "mocha": "~1.12.0"
   },
   "directories": {
     "test": "test"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "./node_modules/.bin/mocha"
   },
   "keywords": [
     "mongoose",


### PR DESCRIPTION
- Updated `mongoose` from ~3.5.0 to 3.x.x so that consumers don't end up with multiple versions if they are using later version than 3.5.
- Removed misspelled `getAnsestors` - it seems silly to provide misspelled variations of method name - where do you draw the line on that?
